### PR TITLE
changes to the readme, and widen the verson constraints on logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ dart-coveralls
 ==============
 [![Coverage Status](https://coveralls.io/repos/Adracus/dart-coveralls/badge.png)](https://coveralls.io/r/Adracus/dart-coveralls)
 
-Calculate coverage of your dart scripts, format it to LCOV and send it to coveralls
+Calculate coverage of your dart scripts, format it to LCOV and send it to
+[coveralls.io](https://coveralls.io/).
 
 ### Usage
 This package consists of a single command line tool `dart_coveralls` with
@@ -15,26 +16,26 @@ This command calculates the coverage of a given package. Use the tool like this:
 dart dart_coveralls.dart calc [--workers, --output, --package-root] test.dart
 ```
 
-* --workers: The number of workers used to parse LCOV information
-* --output: The output file path, if not given stdout
-* --package-root: The root of the analyzed package, default `.`
-* test.dart: The path of the test file on which coverage will be collected
+* `--workers`: The number of workers used to parse LCOV information
+* `--output`: The output file path, if not given stdout
+* `--package-root`: The root of the analyzed package, default `.`
+* `test.dart`: The path of the test file on which coverage will be collected
 
 #### The `report` command
-This command calculates and then sends the coverage data to coveralls.io. Usage of
-the tool is as follows:
+This command calculates and then sends the coverage data to coveralls.io. Usage
+of the tool is as follows:
 
 ```
 dart dart_coveralls.dart report [--workers, --token, --package-root, --debug, --retry] test.dart
 ```
 
-* --workers: The number of workers used to parse LCOV information
-* --token: The token for coveralls.io. The token can also be set as an
+* `--workers`: The number of workers used to parse LCOV information
+* `--token`: The token for coveralls.io. The token can also be set as an
   environment variable called `REPO_TOKEN`.
-* --package-root: The root of the analyzed package, default `.`
-* --debug: Prints additional debug information
-* --retry: The number of retries to submit data to coveralls
-* test.dart: The path of the test file on which coverage will be collected
+* `--package-root`: The root of the analyzed package, default `.`
+* `--debug`: Prints additional debug information
+* `--retry`: The number of retries to submit data to coveralls
+* `test.dart`: The path of the test file on which coverage will be collected
 
 #### The `send` command
 This command sends coverage collected in an LCOV-File to coveralls.io.
@@ -43,11 +44,12 @@ This command sends coverage collected in an LCOV-File to coveralls.io.
 dart dart_coveralls.dart send [--token, --package-root, --retry] lcov.file
 ```
 
-* --token: The token for coveralls.io. The token can also be set as an
+* `--token`: The token for coveralls.io. The token can also be set as an
   environment variable called `REPO_TOKEN`.
-* --package-root: The root of the analyzed package, default `.`
-* --retry: The number of retries to submit data to coveralls
-* lcov.file: The LCOV file which should be reported to coveralls
+* `--package-root`: The root of the analyzed package, default `.`
+* `--retry`: The number of retries to submit data to coveralls
+* `lcov.file`: The LCOV file which should be reported to coveralls
 
+### Contributing
 
 Help and Pull Requests are highly appreciated :)

--- a/lib/dart_coveralls.dart
+++ b/lib/dart_coveralls.dart
@@ -11,8 +11,6 @@ import 'package:logging/logging.dart';
 import 'package:mockable_filesystem/filesystem.dart';
 import 'process_system.dart';
 
-export 'package:logging/logging.dart';
-
 part "git_data.dart";
 
 final Logger log = new Logger("dart_coveralls");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   coverage: '>=0.5.0 <0.6.0'
   http: '>=0.11.1+1 <0.12.0'
   path: '>=1.3.0 <2.0.0'
-  logging: ">=0.9.2 <0.9.3"
+  logging: ">=0.9.2 <0.10.0"
   yaml: ">=2.1.2 <3.0.0"
   mockable_filesystem: ">=0.0.3 <0.1.0"
 dev_dependencies:


### PR DESCRIPTION
This PR contains some styling tweaks the the readme, and widens the version constraint on `logging`. `>=0.9.2 <0.9.3` is pretty narrow, and would cause problems if another package needed to import dart_coveralls (and other deps for that package had different, narrow constraints on `logging`). It looks like the reason for the narrow constraint was because of the export of the logging package; that export didn't _look_ like it was needed.

Nothing here's too critical; comments welcome!
