### PR TITLE
Get the branch name out of the CI_BRANCH env variable if available.

### DIFF
--- a/lib/src/git_data.dart
+++ b/lib/src/git_data.dart
@@ -131,6 +131,8 @@ class GitBranch {
       {ProcessSystem processSystem: const ProcessSystem(),
       Map<String, String> environment}) {
     if (null == environment) environment = Platform.environment;
+    if (null != environment["CI_BRANCH"]) return environment[
+        "CI_BRANCH"];
     if (null != environment["TRAVIS_BRANCH"]) return environment[
         "TRAVIS_BRANCH"];
     var args = ["rev-parse", "--abbrev-ref", "HEAD"];


### PR DESCRIPTION
Codeship saves the current branch in the `CI_BRANCH` environment variable. The default command to get the branch name won't work (for similar reasons as on travis), because the clone is in detached head state.