### PR TITLE
support 0.7.x coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.3.0+1
+
+* Support the latest `coverage` `0.7.0` series releases.
+
 ### 0.3.0
 
 * `serviceName` was removed from `CommandLineClient`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_coveralls
-version: 0.3.0
+version: 0.3.0+1
 author: Axel Christ <adracus@gmail.com>
 description: |-
   Pub package to calculate coverage, format it
@@ -9,7 +9,7 @@ environment:
   sdk: '>=1.9.0 <2.0.0'
 dependencies:
   args: '>=0.12.0+2 <0.14.0'
-  coverage: '>=0.6.4 <0.7.0'
+  coverage: '>=0.6.4 <0.8.0'
   http: '>=0.11.1+1 <0.12.0'
   logging: '>=0.9.2 <0.12.0'
   mockable_filesystem: '>=0.0.3 <0.1.0'


### PR DESCRIPTION
We're currently broken on `Dart 1.11-dev.0.5` without this change.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/duse-io/dart-coveralls/43)
<!-- Reviewable:end -->
