### PR TITLE
Support coverage v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.5.0
+
+* Support the latest `coverage` `0.9.0` series releases, dropping
+  support for `packages` directories, replaced by the `.packages`file.
+
 ### 0.4.0
 
 * Add an upload-only option, which does not run any script

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ dart_coveralls calc [--workers, --output, --package-root] test.dart
 
 * `--workers`: The number of workers used to parse LCOV information
 * `--output`: The output file path, if not given stdout
-* `--package-root`: Where to find packages, that is, "package:..." imports.
-  (defaults to "packages")
+* `--packages`: Where to find the packages file, that is, "package:..." imports.
+  (defaults to ".packages")
+* `--package-root`: Ignored/Deprecated. Package directories are no longer supported.
+  (defaults to ".packages")
 * `test.dart`: The path of the test file on which coverage will be collected
 
 #### The `report` command
@@ -40,8 +42,10 @@ dart_coveralls report <options> <test file>
 * `--token` –Token for coveralls
 * `--workers` – Number of workers for parsing
   (defaults to "1")
-* `--package-root` Where to find packages, that is, "package:..." imports.
-  (defaults to "packages")
+* `--packages`: Where to find the packages file, that is, "package:..." imports.
+  (defaults to ".packages")
+* `--package-root`: Ignored/Deprecated. Package directories are no longer supported.
+  (defaults to ".packages")
 * `--debug` Prints debug information
 * `--retry` Number of retries
   (defaults to "10")
@@ -66,8 +70,10 @@ dart_coveralls upload <options> <directory containing coverage reports from the 
 * `--token` –Token for coveralls
 * `--workers` – Number of workers for parsing
   (defaults to "1")
-* `--package-root` Where to find packages, that is, "package:..." imports.
-  (defaults to "packages")
+* `--packages`: Where to find the packages file, that is, "package:..." imports.
+  (defaults to ".packages")
+* `--package-root`: Ignored/Deprecated. Package directories are no longer supported.
+  (defaults to ".packages")
 * `--debug` Prints debug information
 * `--retry` Number of retries
   (defaults to "10")

--- a/bin/dart_coveralls.dart
+++ b/bin/dart_coveralls.dart
@@ -19,6 +19,7 @@ void main(List<String> args) {
 
   Chain.capture(() async {
     await hub.parseAndExecute(args);
+    exit(0);
   }, onError: (error, chain) {
     print(error);
     print(chain.terse);

--- a/bin/src/calc.dart
+++ b/bin/src/calc.dart
@@ -60,6 +60,9 @@ ArgParser _initializeParser() => new ArgParser(allowTrailingOptions: true)
   ..addFlag("help", help: "Prints this help", negatable: false)
   ..addOption("workers", help: "Number of workers for parsing", defaultsTo: "1")
   ..addOption("output", help: "Output file path")
+  ..addOption("packages",
+      help: 'Where to find the packages file, that is, "package:..." imports.',
+      defaultsTo: ".packages")
   ..addOption("package-root",
-      help: 'Where to find packages, that is, "package:..." imports.',
-      defaultsTo: "packages");
+      help: 'Ignored/Deprecated. Package directories are no longer supported.',
+      defaultsTo: ".packages");

--- a/bin/src/report.dart
+++ b/bin/src/report.dart
@@ -42,9 +42,9 @@ class ReportPart extends CommandLinePart {
 
     if (res.rest.length != 1) return print("Please specify a test file to run");
 
-    var pRoot = new Directory(res["package-root"]);
-    if (!pRoot.existsSync()) return print("Root directory does not exist");
-    log.info(() => "Package root is ${pRoot.absolute.path}");
+    FileSystemEntity pRoot = new File(res["packages"]);
+    if (!pRoot.existsSync()) return print("Packages file does not exist");
+    log.info(() => "Packages file is ${pRoot.absolute.path}");
 
     var file = new File(res.rest.single);
     if (!file.existsSync()) return print("Dart file does not exist");
@@ -102,9 +102,12 @@ ArgParser _initializeParser() => new ArgParser(allowTrailingOptions: true)
       help: "Token for coveralls. If not provided environment values REPO_TOKEN"
       " and COVERALLS_TOKEN are used if they exist.")
   ..addOption("workers", help: "Number of workers for parsing", defaultsTo: "1")
+  ..addOption("packages",
+      help: 'Where to find the packages file, that is, "package:..." imports.',
+      defaultsTo: ".packages")
   ..addOption("package-root",
-      help: 'Where to find packages, that is, "package:..." imports.',
-      defaultsTo: "packages")
+      help: 'Ignored/Deprecated. Package directories are no longer supported.',
+      defaultsTo: ".packages")
   ..addFlag("debug",
       help: "Prints all log information. Equivalent to `--log-level all`",
       negatable: false)

--- a/bin/src/upload.dart
+++ b/bin/src/upload.dart
@@ -27,7 +27,7 @@ class UploadPart extends CommandLinePart {
       });
     }
 
-    var pRoot = new Directory(res["package-root"]);
+    var pRoot = new File(res["packages"]);
     var directory = new Directory(res.rest.single);
     var dryRun = res["dry-run"];
     var token = res["token"];
@@ -39,8 +39,8 @@ class UploadPart extends CommandLinePart {
     var printJson = res["print-json"];
 
     if (!pRoot
-        .existsSync()) return print("Package root directory does not exist");
-    log.info(() => "Package root is ${pRoot.absolute.path}");
+        .existsSync()) return print("Packages file does not exist");
+    log.info(() => "Packages file is ${pRoot.absolute.path}");
     if (!directory.existsSync()) return print(
         "Directory containing VM coverage files does not exist");
     log.info(() =>
@@ -77,9 +77,12 @@ ArgParser _initializeParser() => new ArgParser(allowTrailingOptions: true)
   ..addOption("token",
       help: "Token for coveralls", defaultsTo: Platform.environment["test"])
   ..addOption("workers", help: "Number of workers for parsing", defaultsTo: "1")
+  ..addOption("packages",
+      help: 'Where to find the packages file, that is, "package:..." imports.',
+      defaultsTo: ".packages")
   ..addOption("package-root",
-      help: 'Where to find packages, that is, "package:..." imports.',
-      defaultsTo: "packages")
+      help: 'Ignored/Deprecated. Package directories are no longer supported.',
+      defaultsTo: ".packages")
   ..addFlag("debug", help: "Prints debug information", negatable: false)
   ..addOption("retry", help: "Number of retries", defaultsTo: "10")
   ..addFlag("dry-run",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: dart_coveralls
-version: 0.4.0
+version: 0.5.0
 author: Axel Christ <adracus@gmail.com>
 description: |-
   Pub package to calculate coverage, format it
   to LCOV and send it to coveralls
 homepage: https://github.com/duse-io/dart-coveralls
 environment:
-  sdk: '>=1.9.0 <2.0.0'
+  sdk: '>=1.9.0 <1.22.0'
 dependencies:
   args: '>=0.12.0+2 <0.14.0'
-  coverage: '>=0.6.4 <0.8.0'
+  coverage: '>=0.6.4 <0.10.0'
   http: '>=0.11.1+1 <0.12.0'
   logging: '>=0.9.2 <0.12.0'
   mockable_filesystem: '>=0.0.3 <0.1.0'


### PR DESCRIPTION
Hi @Adracus, as discussed elsewhere, here are the changes required for dart-coveralls to work again. Note: In `collect_lcov.dart` L114, the process doesn't complete the `Future`, thus I refactored to not use `await`. It will do for now, but with the changes to Observatory URLs coming with Dart 1.22.0, it will require a revisit.