### PR TITLE
Make dart_coveralls strong-mode clean.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,2 @@
 analyzer:
   strong-mode: true
-  

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  strong-mode: true
+  

--- a/lib/src/cli_client.dart
+++ b/lib/src/cli_client.dart
@@ -1,6 +1,6 @@
 library dart_coveralls.cli_client;
 
-import 'dart:async' show Future, Completer;
+import 'dart:async' show Future;
 import 'dart:convert';
 import 'dart:io';
 
@@ -21,8 +21,11 @@ class CommandLineClient {
 
   CommandLineClient._(this.projectDirectory, this.packageRoot, this.token);
 
-  factory CommandLineClient({String projectDirectory, String packageRoot,
-      String token, Map<String, String> environment}) {
+  factory CommandLineClient(
+      {String projectDirectory,
+      String packageRoot,
+      String token,
+      Map<String, String> environment}) {
     if (projectDirectory == null) {
       projectDirectory = p.current;
     }
@@ -53,11 +56,15 @@ class CommandLineClient {
     return environment['COVERALLS_TOKEN'];
   }
 
-  Future<CoverallsResult> reportToCoveralls(String testFile, {int workers,
+  Future<CoverallsResult> reportToCoveralls(String testFile,
+      {int workers,
       ProcessSystem processSystem: const ProcessSystem(),
-      String coverallsAddress, bool dryRun: false,
-      bool throwOnConnectivityError: false, int retry: 0,
-      bool excludeTestFiles: false, bool printJson}) async {
+      String coverallsAddress,
+      bool dryRun: false,
+      bool throwOnConnectivityError: false,
+      int retry: 0,
+      bool excludeTestFiles: false,
+      bool printJson}) async {
     var rawLcov = await getLcovResult(testFile,
         workers: workers, processSystem: processSystem);
 
@@ -75,11 +82,15 @@ class CommandLineClient {
   }
 
   Future<CoverallsResult> convertAndUploadToCoveralls(
-      Directory containsVmReports, {int workers,
+      Directory containsVmReports,
+      {int workers,
       ProcessSystem processSystem: const ProcessSystem(),
-      String coverallsAddress, bool dryRun: false,
-      bool throwOnConnectivityError: false, int retry: 0,
-      bool excludeTestFiles: false, bool printJson}) async {
+      String coverallsAddress,
+      bool dryRun: false,
+      bool throwOnConnectivityError: false,
+      int retry: 0,
+      bool excludeTestFiles: false,
+      bool printJson}) async {
     var collector =
         new LcovCollector(packageRoot, processSystem: processSystem);
 
@@ -97,10 +108,14 @@ class CommandLineClient {
   }
 
   Future<CoverallsResult> uploadToCoveralls(CoverageResult coverageResult,
-      {int workers, ProcessSystem processSystem: const ProcessSystem(),
-      String coverallsAddress, bool dryRun: false,
-      bool throwOnConnectivityError: false, int retry: 0,
-      bool excludeTestFiles: false, bool printJson}) async {
+      {int workers,
+      ProcessSystem processSystem: const ProcessSystem(),
+      String coverallsAddress,
+      bool dryRun: false,
+      bool throwOnConnectivityError: false,
+      int retry: 0,
+      bool excludeTestFiles: false,
+      bool printJson}) async {
     var lcov = LcovDocument.parse(coverageResult.result.toString());
 
     var serviceName = travis.getServiceName(Platform.environment);
@@ -127,6 +142,7 @@ class CommandLineClient {
       stderr.writeln('Error sending results');
       stderr.writeln(e);
       stderr.writeln(new Chain.forTrace(stack).terse);
+      return null;
     }
   }
 }

--- a/lib/src/collect_lcov.dart
+++ b/lib/src/collect_lcov.dart
@@ -57,9 +57,11 @@ class LcovCollector {
       {this.processSystem: const ProcessSystem(), this.sdkRoot}) {}
 
   Future<CoverageResult<String>> convertVmReportsToLcov(
-      Directory directoryContainingVmReports, {int workers: 1}) async {
-    var reportFiles = await directoryContainingVmReports
+      Directory directoryContainingVmReports,
+      {int workers: 1}) async {
+    List<File> reportFiles = await directoryContainingVmReports
         .list(recursive: false, followLinks: false)
+        .where((FileSystemEntity f) => f is File)
         .toList();
 
     var hitmap = await parseCoverage(reportFiles, workers);
@@ -113,7 +115,9 @@ class LcovCollector {
       stderr.writeln(result.stdout);
       stderr.writeln('stderr:');
       stderr.writeln(result.stderr);
-      throw new ProcessException(Platform.executable, args,
+      throw new ProcessException(
+          Platform.executable,
+          args,
           'There was a critical error. Exit code: ${result.exitCode}',
           result.exitCode);
     }

--- a/lib/src/coveralls_entities.dart
+++ b/lib/src/coveralls_entities.dart
@@ -1,6 +1,6 @@
 library dart_coveralls.coveralls_entities;
 
-import 'dart:io' show Directory, File, Platform, FileSystemEntity, Link;
+import 'dart:io' show Directory, File, FileSystemEntity;
 
 import 'package:mockable_filesystem/filesystem.dart';
 import 'package:path/path.dart' as p;
@@ -114,10 +114,10 @@ class SourceFileReport {
   }
 
   Map toJson() => {
-    "name": sourceFile.name,
-    "source": sourceFile.source,
-    "coverage": coverage.values.map((lv) => lv.lineCount).toList()
-  };
+        "name": sourceFile.name,
+        "source": sourceFile.source,
+        "coverage": coverage.values.map((lv) => lv.lineCount).toList()
+      };
 }
 
 class SourceFile {
@@ -172,13 +172,14 @@ class Coverage {
   static Coverage parse(String lcovContent) {
     var numeration =
         lcovContent.split("\n").where((str) => str.isNotEmpty).toList();
-    var values = [];
+    List<LineValue> values = [];
     var current = 1;
     for (int i = 0; i < numeration.length; i++) {
       var lineValue = LineValue.parse(numeration[i]);
       int distance = lineValue.lineNumber - values.length - 1;
-      if (distance > 0) values.addAll(
-          new List.generate(distance, (_) => new LineValue.noCount(current++)));
+      if (distance > 0)
+        values.addAll(new List.generate(
+            distance, (_) => new LineValue.noCount(current++)));
       values.add(lineValue);
       current++;
     }

--- a/test/coveralls_collect_lcov_test.dart
+++ b/test/coveralls_collect_lcov_test.dart
@@ -1,6 +1,6 @@
 library dart_coveralls.test.collect_lcov;
 
-import 'dart:io' show Directory, File, Platform;
+import 'dart:io' show File;
 
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -23,8 +23,9 @@ void main() {
           equals("SF:string_scanner/src/utils.dart"));
       expect(document.parts.last.fileName,
           equals("string_scanner/src/utils.dart"));
-      expect(document.parts.last.content, equals(
-          "DA:10,0\nDA:14,0\nDA:15,0\nDA:16,0" +
+      expect(
+          document.parts.last.content,
+          equals("DA:10,0\nDA:14,0\nDA:15,0\nDA:16,0" +
               "\nDA:17,0\nDA:22,0\nDA:23,0\nDA:26,0\nDA:27,0"));
     });
   });

--- a/test/mock_classes.dart
+++ b/test/mock_classes.dart
@@ -7,26 +7,16 @@ import 'package:dart_coveralls/dart_coveralls.dart';
 import 'package:mock/mock.dart';
 
 @proxy
-class FileSystemMock extends Mock implements FileSystem {
-  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
+class FileSystemMock extends Mock implements FileSystem {}
 
 @proxy
-class FileMock extends Mock implements File {
-  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
+class FileMock extends Mock implements File {}
 
 @proxy
-class DirectoryMock extends Mock implements Directory {
-  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
+class DirectoryMock extends Mock implements Directory {}
 
 @proxy
-class ProcessResultMock extends Mock implements ProcessResult {
-  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
+class ProcessResultMock extends Mock implements ProcessResult {}
 
 @proxy
-class ProcessSystemMock extends Mock implements ProcessSystem {
-  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
-}
+class ProcessSystemMock extends Mock implements ProcessSystem {}


### PR DESCRIPTION
Added an analysis_options.yaml file, enabled strong_mode
and then burned through the issues from the analyzer.