### PR TITLE
0.6.0+4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### unreleased
+### 0.6.0+4
 
+* Fixed parser to ignore lines that are not `DA` line coverage entries.
 * Support for `--preview-dart-2` removed and SDK lower bound bumped to `2.0.0-dev.64.1`.
 
 ### 0.6.0+3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_coveralls
-version: 0.6.0+3
+version: 0.6.0+4
 author: Axel Christ <adracus@gmail.com>
 description: |-
   Pub package to calculate coverage, format it


### PR DESCRIPTION
# 0.6.0+4

* Fixed parser to ignore lines that are not `DA` line coverage entries.
* Support for `--preview-dart-2` removed and SDK lower bound bumped to `2.0.0-dev.64.1`.

/cc @bkonyi @nilsdoehring