### PR TITLE
Fix failing Travis CI builds triggered by tag push

### DIFF
--- a/lib/src/git_data.dart
+++ b/lib/src/git_data.dart
@@ -148,7 +148,7 @@ class GitBranch {
   static GitBranch getCurrent(Directory dir,
       {ProcessSystem processSystem: const ProcessSystem()}) {
     var name = getCurrentBranchName(dir, processSystem: processSystem);
-    var args = ["show-ref", "$name", "--heads"];
+    var args = ["show-ref", "$name", "--heads --tags"];
     var result =
         processSystem.runProcessSync("git", args, workingDirectory: dir.path);
     if (0 != result.exitCode)


### PR DESCRIPTION
If the build was triggered by pushing a tag then TravisCI branch actually is a tag, not a branch.
Example of failing build: https://travis-ci.com/syberside/Activatory/builds/97164684
This should fix the problem